### PR TITLE
Optimize our Travis Workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ language: node_js
 node_js: "6"
 install: "npm install"
 script: "npm run test"
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8
+dist: trusty
+sudo: false
+cache:
+  directories:
+    - "node_modules"


### PR DESCRIPTION
This switches to using a sudo-less Trusty dist and turns on caching the `node_modules` folder. This looks to significantly speed up the validation times. 