### PR TITLE
documentation is moved to readme.io

### DIFF
--- a/libraries/c-sharp/riotgamesapiaspnetcore.json
+++ b/libraries/c-sharp/riotgamesapiaspnetcore.json
@@ -9,12 +9,12 @@
          "url":"https://www.nuget.org/packages/RiotGamesApi.AspNetCore/"
       },
       {
-         "name":"Usage",
-         "url":"https://github.com/msx752/RiotGamesApi.AspNetCore/blob/master/README.md#step-by-step-configuration"
+       "name":"Documentation",
+       "url":"https://riotgamesapi.readme.io/"
       },
       {
-         "name":"NuGet(Only v3 API ClassLibrary)",
-         "url":"https://www.nuget.org/packages/RiotGamesApi.AspNetCore.RiotApi/"
+       "name":"V3ClassLibrary",
+       "url":"https://www.nuget.org/packages/RiotGamesApi.AspNetCore.RiotApi/"
       }
    ],
    "metadata":{


### PR DESCRIPTION
i am sorry for frequently created PR, but readme.io just approved the documentation website, this is last one .
new documentation is based on https://riotgamesapi.readme.io/