### PR TITLE
big changes

### DIFF
--- a/libraries/c-sharp/riotgamesapi
+++ b/libraries/c-sharp/riotgamesapi
@@ -1,7 +1,7 @@
 {
    "owner":"Msx752",
-   "repo":"RiotGamesApi",
-   "description":"widely expanded RiotGames C# API v3 and upper Wrapper (.Net Core, Portable, .Net 4.6.2)",
+   "repo":"RiotGamesAPI",
+   "description":"Portable RiotGames API v3 and upper Wrapper",
    "language":"C#",
    "links":[
       {
@@ -18,7 +18,7 @@
       },
       {
        "name":"Documentation",
-       "url":"https://riotgamesapi.readme.io/"
+       "url":"https://riotgamesapi.readme.io/docs"
       }
    ],
    "metadata":{

--- a/libraries/c-sharp/riotgamesapiaspnetcore.json
+++ b/libraries/c-sharp/riotgamesapiaspnetcore.json
@@ -1,20 +1,24 @@
 {
    "owner":"Msx752",
-   "repo":"RiotGamesApi.AspNetCore",
-   "description":"LeagueOfLegends v3 and upper API wrapper .Net Core 1.1",
+   "repo":"RiotGamesApi",
+   "description":"widely expanded RiotGames C# API v3 and upper Wrapper (.Net Core, Portable, .Net 4.6.2)",
    "language":"C#",
    "links":[
       {
-         "name":"NuGet",
+         "name":"AspNetCore",
          "url":"https://www.nuget.org/packages/RiotGamesApi.AspNetCore/"
+      },
+      {
+         "name":"Portable",
+         "url":"https://www.nuget.org/packages/RiotGamesApi/"
+      },
+      {
+         "name":"AspNet",
+         "url":"https://www.nuget.org/packages/RiotGamesApi.AspNet/"
       },
       {
        "name":"Documentation",
        "url":"https://riotgamesapi.readme.io/"
-      },
-      {
-       "name":"V3ClassLibrary",
-       "url":"https://www.nuget.org/packages/RiotGamesApi.AspNetCore.RiotApi/"
       }
    ],
    "metadata":{


### PR DESCRIPTION
- i added one portable api wrapper(.Net Standard 1.6) and two .net middleware extensions (Asp.Net 4.6.2, Asp.Net Core),
- now RiotGamesApi library can easy support different game type of RiotGamesCompany (i know, now only LeagueOfLegends but may be can added new games??).
-  library now can support multiple api version (added for the future)