### PR TITLE
 extension packages are deprecated 

### DIFF
--- a/libraries/c-sharp/riotgamesapi.json
+++ b/libraries/c-sharp/riotgamesapi.json
@@ -1,20 +1,20 @@
 {
    "owner":"Msx752",
    "repo":"RiotGamesAPI",
-   "description":"Portable RiotGames API v3 and upper Wrapper",
+   "description":"Riot Games API Library v3 (all in one)",
    "language":"C#",
    "links":[
       {
          "name":"AspNetCore",
-         "url":"https://www.nuget.org/packages/RiotGamesApi.AspNetCore/"
+         "url":"https://www.nuget.org/packages/RiotGamesAPI/"
       },
       {
-         "name":"Portable",
-         "url":"https://www.nuget.org/packages/RiotGamesApi/"
+         "name":"NetStandard",
+         "url":"https://www.nuget.org/packages/RiotGamesAPI/"
       },
       {
          "name":"AspNet",
-         "url":"https://www.nuget.org/packages/RiotGamesApi.AspNet/"
+         "url":"https://www.nuget.org/packages/RiotGamesAPI/"
       },
       {
        "name":"Documentation",


### PR DESCRIPTION
all in one package there is no extension library from now.

notice about changes: https://github.com/msx752/RiotGamesAPI/issues/12