### PR TITLE
Remove outdated NuGet link from RiotSharp

### DIFF
--- a/libraries/c-sharp/riotsharpaspnetcore.json
+++ b/libraries/c-sharp/riotsharpaspnetcore.json
@@ -3,12 +3,7 @@
   "repo": "RiotSharp",
   "language": "C#",
   "description": "RiotSharp's ASP.NET Core integration",
-  "links": [
-    {
-      "name": "NuGet",
-      "url": "https://www.nuget.org/packages/RiotSharp"
-    }
-  ],
+  "links": [],
   "metadata": {
     "v3": true,
     "async": true,


### PR DESCRIPTION
The NuGet hasn't been updated in a long time. Users will need to compile from github manually