### PR TITLE
Updating version tag to v4

### DIFF
--- a/libraries/swift/leagueapi.json
+++ b/libraries/swift/leagueapi.json
@@ -16,7 +16,7 @@
     ],
     "metadata": {},
     "tags": [
-        "v3",
+        "v4",
         "rate-limiting"
     ]
 }


### PR DESCRIPTION
LeagueAPI supports Riot API v4 now