### PR TITLE
Update RiotBlossom documentation link

### DIFF
--- a/libraries/c-sharp/riotblossom.json
+++ b/libraries/c-sharp/riotblossom.json
@@ -10,7 +10,7 @@
         },
         {
             "name": "Documentation",
-            "url":  "https://github.com/BlossomiShymae/RiotBlossom/blob/master/README.md"
+            "url":  "https://blossomishymae.github.io/RiotBlossom/"
         }
     ],
     "metadata": { },


### PR DESCRIPTION
I updated the documentation for RiotBlossom to be on GitHub pages instead of README.md... (ꈍ꒳ꈍ)