### PR TITLE
Add yasuo.js (TypeScript & JavaScript) — modern, zero-dependency Riot Games API client

### DIFF
--- a/libraries/javascript/yasuojs.json
+++ b/libraries/javascript/yasuojs.json
@@ -1,0 +1,38 @@
+{
+    "owner": "justadev-afk",
+    "repo": "yasuo.js",
+    "description": "The modern, fully-typed, zero-dependency Riot Games API client for TypeScript & JavaScript — the evolution of twisted. A query-builder API with lazy relations, reactive retry (always on) plus opt-in proactive rate limiting, pluggable caching (in-memory / Redis / Cloudflare KV), async-iterator pagination and a single-file dual ESM + CJS build.",
+    "language": "JavaScript",
+    "links": [
+        {
+            "name": "npm",
+            "url": "https://www.npmjs.com/package/yasuo.js"
+        },
+        {
+            "name": "GitHub",
+            "url": "https://github.com/justadev-afk/yasuo.js"
+        },
+        {
+            "name": "Documentation",
+            "url": "https://docs.yasuo.gg/"
+        },
+        {
+            "name": "Live Demo",
+            "url": "https://www.yasuo.gg"
+        }
+    ],
+    "metadata": {
+        "version": "0.1.5",
+        "dependencies": 0
+    },
+    "tags": [
+        "v4",
+        "v5",
+        "lol",
+        "tft",
+        "rate-limiting",
+        "caching",
+        "ts",
+        "zero-dependency"
+    ]
+}

--- a/libraries/typescript/yasuojs.json
+++ b/libraries/typescript/yasuojs.json
@@ -1,0 +1,38 @@
+{
+    "owner": "justadev-afk",
+    "repo": "yasuo.js",
+    "description": "The modern, fully-typed, zero-dependency Riot Games API client for TypeScript — the evolution of twisted. A query-builder API with lazy relations, reactive retry (always on) plus opt-in proactive rate limiting, pluggable caching (in-memory / Redis / Cloudflare KV), async-iterator pagination and a single-file dual ESM + CJS build.",
+    "language": "TypeScript",
+    "links": [
+        {
+            "name": "npm",
+            "url": "https://www.npmjs.com/package/yasuo.js"
+        },
+        {
+            "name": "GitHub",
+            "url": "https://github.com/justadev-afk/yasuo.js"
+        },
+        {
+            "name": "Documentation",
+            "url": "https://docs.yasuo.gg/"
+        },
+        {
+            "name": "Live Demo",
+            "url": "https://www.yasuo.gg"
+        }
+    ],
+    "metadata": {
+        "version": "0.1.5",
+        "dependencies": 0
+    },
+    "tags": [
+        "v4",
+        "v5",
+        "lol",
+        "tft",
+        "rate-limiting",
+        "caching",
+        "ts",
+        "zero-dependency"
+    ]
+}


### PR DESCRIPTION
## Add **yasuo.js** — a modern, zero-dependency Riot Games API client for TypeScript

This PR adds the library to **both** the TypeScript and JavaScript lists — `libraries/typescript/yasuojs.json` and `libraries/javascript/yasuojs.json`. yasuo.js is written in TypeScript but ships a compiled JS + `.d.ts` build, so it's equally usable from plain JavaScript — same dual-listing pattern as [`twisted`](https://github.com/WxWatch/riot-api-libraries/blob/master/libraries/javascript/twisted.json). No existing files are touched.

**yasuo.js** is the spiritual successor to [twisted](https://www.npmjs.com/package/twisted) — same one-client, typed-response ergonomics, rebuilt around a query-builder API with **zero runtime dependencies**.

### Links

| | |
| --- | --- |
| 📦 **npm** | https://www.npmjs.com/package/yasuo.js |
| 🐙 **GitHub** | https://github.com/justadev-afk/yasuo.js |
| 📚 **Docs** | https://docs.yasuo.gg/ |
| 🎮 **Live demo** | https://www.yasuo.gg |

### Why it belongs here

- **Zero runtime dependencies** — nothing pulled into your `node_modules` (verify: `npm view yasuo.js dependencies` → empty). Just fully-typed TypeScript.
- **First-class TypeScript** — regions, queues, tiers, divisions and match types are enums (no magic strings); errors are typed `ApiError` subclasses you narrow with `instanceof`.
- **Query builders + lazy relations** — `account.summoner(region).matchIds().execute()` runs *only* the final request; relations auto-route (e.g. `Region.KR` → `RegionGroup.ASIA`) so you never re-specify routing.
- **Rate limiting done right** — reactive `retry-after` backoff is always on; opt-in **proactive** pacing reads Riot's `x-app`/`x-method` rate-limit headers and stays *under* the advertised limits, per host and per method.
- **Pluggable caching** — in-memory by default; **Redis** or **Cloudflare Workers KV** with no extra dependency.
- **Async-iterator pagination** — `for await` over a player's entire match history, paced by the limiter.
- **Custom transport + axios-style middleware**, a leveled logger, and a **single-file dual ESM + CJS** build (Node 18+ / Bun / Deno).
- **51 endpoints** across LoL (33), TFT (14) and the Riot Account API (4), plus Data Dragon static data.

### Live proof it works

[**www.yasuo.gg**](https://www.yasuo.gg) is a complete, open-source League of Legends summoner-profile site + public JSON API, built **entirely** on this library and running on Cloudflare Workers ([source](https://github.com/justadev-afk/yasuo.gg)). It even ships an interactive playground that shows the exact yasuo.js code behind each lookup.

### Entry checklist

- [x] Files follow the naming rule (repo lowercased, non-alphanumeric stripped) → `yasuojs.json`, added under both `libraries/typescript/` and `libraries/javascript/`
- [x] No filename collision in either folder
- [x] Validates against `schema.json` (`additionalProperties: false` satisfied)
- [x] Includes the `v4` tag (also `v5`) so it surfaces in the docs + `#lol-dev`
- [x] `rate-limiting` tag — the library natively handles rate limiting
- [x] `tft` tag — full TFT API support

